### PR TITLE
feat: add Copilot panel keymap, clipboard range copy, and update Copilot panel layout

### DIFF
--- a/nvim/.config/nvim/lua/config/keymaps.lua
+++ b/nvim/.config/nvim/lua/config/keymaps.lua
@@ -23,21 +23,48 @@ vim.keymap.set({ "n", "x" }, "<leader>ca", function()
 end, { noremap = true, silent = true })
 
 -- Open opencode in right split
-vim.keymap.set('n', '<leader>ao', function()
+vim.keymap.set("n", "<leader>ao", function()
   -- Check if 'opencode' command exists
-  local opencode_exists = vim.fn.system('command -v opencode'):match('opencode')
+  local opencode_exists = vim.fn.system("command -v opencode"):match("opencode")
   if not opencode_exists then
     vim.notify("'opencode' command not found. Please install it to use this feature.", vim.log.levels.ERROR)
     return
   end
   -- Open a vertical split on the right
-  vim.cmd('vsplit')
+  vim.cmd("vsplit")
   -- Open a terminal in the new split and run 'opencode'
-  vim.cmd('terminal opencode')
+  vim.cmd("terminal opencode")
   -- Get the window ID of the terminal
   local terminal_win = vim.api.nvim_get_current_win()
   -- Move cursor explicitly to the terminal window
   vim.api.nvim_set_current_win(terminal_win)
   -- Enter terminal insert mode to make it interactable
-  vim.cmd('startinsert')
-end, { desc = 'Open opencode in right split' })
+  vim.cmd("startinsert")
+  -- Add ability to move between open windows
+end, { desc = "Open opencode in right split" })
+
+-- Open copilot panel with <leader>op
+vim.keymap.set("n", "<leader>ap", ":Copilot panel<CR>", { desc = "Open Copilot Panel" })
+
+-- Terminal: <C-Space> exits to normal mode
+vim.keymap.set("t", "<C-Space>", [[<C-\><C-n>]], { noremap = true, silent = true, desc = "Terminal normal mode" })
+
+-- Visual: <leader>yl copies file:line-range to clipboard
+vim.keymap.set("v", "<leader>yl", function()
+  -- Get project root (current working directory)
+  local project_root = vim.fn.getcwd()
+  -- Get absolute file path and make it relative to project root
+  local abs_path = vim.fn.expand("%:p")
+  local rel_path = abs_path:sub(#project_root + 2) -- +2 to remove "/" after root
+  -- Get visual selection line range
+  local start_line = vim.fn.line("v")
+  local end_line = vim.fn.line(".")
+  if start_line > end_line then
+    start_line, end_line = end_line, start_line
+  end
+  local range_str = "L" .. tostring(start_line) .. "-" .. tostring(end_line)
+  -- Format and copy
+  local result = rel_path .. ":" .. range_str
+  vim.fn.setreg("+", result)
+  vim.notify("Copied: " .. result, vim.log.levels.INFO)
+end, { noremap = true, silent = true, desc = "Copy file:line-range to clipboard" })

--- a/nvim/.config/nvim/lua/config/keymaps.lua
+++ b/nvim/.config/nvim/lua/config/keymaps.lua
@@ -44,7 +44,7 @@ vim.keymap.set("n", "<leader>ao", function()
 end, { desc = "Open opencode in right split" })
 
 -- Open copilot panel with <leader>op
-vim.keymap.set("n", "<leader>ap", ":Copilot panel<CR>", { desc = "Open Copilot Panel" })
+vim.keymap.set("n", "<leader>ap", ":Copilot panel<CR>", { noremap = true, silent = true, desc = "Open Copilot Panel" })
 
 -- Terminal: <C-Space> exits to normal mode
 vim.keymap.set("t", "<C-Space>", [[<C-\><C-n>]], { noremap = true, silent = true, desc = "Terminal normal mode" })

--- a/nvim/.config/nvim/lua/config/keymaps.lua
+++ b/nvim/.config/nvim/lua/config/keymaps.lua
@@ -40,7 +40,6 @@ vim.keymap.set("n", "<leader>ao", function()
   vim.api.nvim_set_current_win(terminal_win)
   -- Enter terminal insert mode to make it interactable
   vim.cmd("startinsert")
-  -- Add ability to move between open windows
 end, { desc = "Open opencode in right split" })
 
 -- Open copilot panel with <leader>op

--- a/nvim/.config/nvim/lua/plugins/copilot.lua
+++ b/nvim/.config/nvim/lua/plugins/copilot.lua
@@ -15,8 +15,8 @@ return {
           open = "<M-CR>",
         },
         layout = {
-          position = "right", -- | top | left | right | horizontal | vertical
-          ratio = 0.5,
+          position = "horizontal", -- | top | left | right | horizontal | vertical
+          ratio = 0.3,
         },
       },
       suggestion = {


### PR DESCRIPTION
- Add <leader>ap to open Copilot panel and <leader>yl to copy file:line-range in visual mode
- Change Copilot panel layout to horizontal with 0.3 ratio for improved usability
- Add terminal normal mode shortcut and minor keymap improvements